### PR TITLE
add Podman network components, closes #54 (#56)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,16 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+RUN mkdir -p /usr/libexec/podman /etc/containers/
+
+RUN curl -L -o /usr/libexec/podman/netavark.gz https://github.com/containers/netavark/releases/download/v1.14.1/netavark.gz && \
+    curl -L -o /usr/libexec/podman/aardvark-dns.gz https://github.com/containers/aardvark-dns/releases/download/v1.14.0/aardvark-dns.gz && \
+    cd /usr/libexec/podman && \
+    gunzip netavark.gz && \
+    gunzip aardvark-dns.gz && \
+    chmod +x netavark && \
+    chmod +x aardvark-dns
+
 RUN mkdir -p /etc/containers/ && touch /etc/containers/registries.conf && echo 'unqualified-search-registries=["docker.io"]' > /etc/containers/registries.conf
 
 COPY policy.json storage.conf registries.conf /etc/containers/
@@ -53,13 +63,21 @@ COPY . .
 # lsflags to strip debug info
 RUN --mount=type=cache,target=/go/pkg/mod/ --mount=type=cache,target="/root/.cache/go-build" go build -ldflags "-s -w" -o server ./cmd/server
 
-FROM alpine:3.13
+FROM scratch
 
 # Create a non-root user and group for better security
 # RUN addgroup -S appgroup && adduser -S 1001 -G appgroup
 RUN addgroup -g 1001 appgroup && adduser -D -G appgroup -u 1001 appuser
 
 WORKDIR /app
+
+RUN mkdir -p /usr/libexec/podman
+
+COPY --from=builder /usr/libexec/podman/netavark /usr/libexec/podman/
+COPY --from=builder /usr/libexec/podman/aardvark-dns /usr/libexec/podman/
+
+RUN chmod +x /usr/libexec/podman/netavark && \
+    chmod +x /usr/libexec/podman/aardvark-dns
 
 USER 1001
 


### PR DESCRIPTION
* add Podman network components, closes #54

Add netavark and aardvark-dns binaries to enable container networking with Podman. Components are downloaded in builder stage and copied to final image:

- netavark v1.14.1 for network configuration
- aardvark-dns v1.14.0 for DNS resolution



* switch base image from Alpine to scratch

Switch the final stage base image from Alpine 3.13 to scratch container to:
- Reduce the final image size
- Minimize the attack surface by removing unnecessary components
- Improve security posture of the containerized application



---------